### PR TITLE
Update author field to use full name

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
 	"version": "0.0.9",
 	"minAppVersion": "0.12.19",
 	"description": "Add captions to images.",
-	"author": "bicarlsen",
+	"author": "Brian Carlsen",
 	"authorUrl": "https://github.com/bicarlsen",
 	"isDesktopOnly": false
 }


### PR DESCRIPTION
Hallo, would you mind accepting this to update the author field to spell out you full name, so it is consistent with the same field in your `obsidian_html_tags_autocomplete` plugin?

https://github.com/bicarlsen/obsidian_html_tags_autocomplete/blob/main/manifest.json

**Motivation**

I was about to write some code in the Obsidian Hub repo, to save us from having to make a manual edit every time we get the latest set of Obsidian community releases, to edit `bicarlsen` back to `Brian Carlsen`, as it picks up the author name from the manifest in this repo...

If it were possible for the author name to be consistent across your plugins, it would be a welcome small simplification to the maintenance of the hub.

We're tracking this in https://github.com/obsidian-community/obsidian-hub/issues/150

Many thanks.